### PR TITLE
feat(Image): Add lazy loading with Intersection Observer

### DIFF
--- a/src/components/image/Image.tsx
+++ b/src/components/image/Image.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Loader } from '../loader/Loader'
 import './Image.css'
 
@@ -9,9 +9,36 @@ export const Image = ({
   src: string
   alt?: string
 }) => {
+  const [isVisible, setIsVisible] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
+  const containerRef = useRef<HTMLDivElement>(null)
 
+  // Observe when the component becomes visible
   useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setIsVisible(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0 }
+    )
+
+    observer.observe(container)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  // Load the image only when visible
+  useEffect(() => {
+    if (!isVisible) return
+
     const img = new window.Image()
     const minLoadingTime = 1000 // 1 second
     const startTime = Date.now()
@@ -32,10 +59,10 @@ export const Image = ({
       img.onload = null
       img.onerror = null
     }
-  }, [src])
+  }, [isVisible, src])
 
   return (
-    <div className="image">
+    <div className="image" ref={containerRef}>
       {isLoading ? (
         <div className="image__loader">
           <Loader />


### PR DESCRIPTION
Images now wait until they become visible on screen before starting
to load. This improves page performance by deferring image loading
until needed, while preserving the existing loader animation and
minimum load time behavior.